### PR TITLE
Fix issue where existing content was not rendered on edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- Nothing changed yet.
+- Fix issue where existing content did not render on edit form and
+  logged error when target content object was deleted
+  [datakurre]
 
 
 2.0.0rc2 (2016-11-24)

--- a/plone/app/standardtiles/templates/existingcontent_view.pt
+++ b/plone/app/standardtiles/templates/existingcontent_view.pt
@@ -64,5 +64,5 @@
   </div>
   </tal:block>
   </tal:block>
-  <body condition="not:nocall:view/content_context"></body>
+  <body tal:condition="not:nocall:view/content_context"></body>
 </html>

--- a/plone/app/standardtiles/tests/test_media.py
+++ b/plone/app/standardtiles/tests/test_media.py
@@ -133,6 +133,35 @@ class ContentTileTests(TestCase):
 
         self.assertIn(u'Hello World!', self.unprivileged_browser.contents)
 
+    def test_existing_content_tile_private(self):
+        """When the current user does not have enough permissions to view
+        the content linked to existing content tile, the tile renders
+        empty"""
+        self.portal.portal_workflow.setDefaultChain(
+            'simple_publication_workflow')
+
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+
+        browser = Browser(self.layer['app'])
+        browser.handleErrors = False
+        browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid
+        )
+
+        self.assertNotIn(u'Hello World!', browser.contents)
+        self.assertIn(u'<body></body>', browser.contents)
+
     def test_edit_existing_content_tile(self):
         """The existing content tile takes the uuid of a content object in the
         site and displays the result of calling its default view's content-core


### PR DESCRIPTION
 due to not enough permissions on traverse and where missing UID caused hard error.

Fixes also https://github.com/plone/plone.app.mosaic/issues/323