### PR TITLE
Basic implementation for forms rendering

### DIFF
--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -14,6 +14,9 @@ from z3c.form import validator
 from zExceptions import Unauthorized
 from zope import schema
 from zope.browser.interfaces import IBrowserView
+from zope.component import queryMultiAdapter
+from zope.pagetemplate.interfaces import IPageTemplate
+from Products.Five.browser.pagetemplatefile import BoundPageTemplate
 from zope.component.hooks import getSite
 from zope.interface import Invalid
 
@@ -119,6 +122,8 @@ class ExistingContentTile(Tile):
         if context is not None:
             item_layout = context.getLayout()
             default_view = context.restrictedTraverse(item_layout)
+            if getattr(default_view, 'update', None):
+                default_view.update()
             return default_view
         return None
 
@@ -129,6 +134,10 @@ class ExistingContentTile(Tile):
             # IBrowserView
             if getattr(default_view, 'index', None):
                 return default_view.index.macros
+            template = queryMultiAdapter(
+                (default_view, default_view.request), IPageTemplate, default=None)
+            if template:
+                return BoundPageTemplate(template, context).macros
         elif default_view:
             # FSPageTemplate
             return default_view.macros

--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -137,7 +137,7 @@ class ExistingContentTile(Tile):
             template = queryMultiAdapter(
                 (default_view, default_view.request), IPageTemplate, default=None)
             if template:
-                return BoundPageTemplate(template, context).macros
+                return BoundPageTemplate(template, default_view.context).macros
         elif default_view:
             # FSPageTemplate
             return default_view.macros

--- a/plone/app/standardtiles/templates/existingcontent_view.pt
+++ b/plone/app/standardtiles/templates/existingcontent_view.pt
@@ -7,7 +7,7 @@
   <tal:block condition="nocall:view/content_context">
   <tal:block condition="nocall:view/item_macros">
   <body tal:define="context nocall:view/content_context;
-                    item_macro nocall:view/item_macros/content-core|nothing;
+                    item_macro nocall:view/item_macros/content-core|nocall:view/item_macros/main|nothing;
                     data view/data;
                     show_title python: data.get('show_title', True);
                     show_description python: data.get('show_description', True)">


### PR DESCRIPTION
The purpose of those modifications is to render a standard plone form in a contenttile.
3 things are done:
1. update the view if there is an update attribute
2. look for a default page template if nothing is in the "index" attribute
3. in the page template, get main macro if content-core macro has not been found.

This doesn't break the default behavior.

Still pending:
the form comes with a title, so the checkbox "show title" will ad a second title.