### PR TITLE
Improve existing content with some additional fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.Python
 *.egg-info
 *.mo
 *.pyc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,15 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+New features:
+
+- Add "show_image", "show_text" and "show_comments" to existing content tile.
+  [cekk]
+
 Bug fixes:
 - Fix non ASCII HTML tile content
   [tomgross]
-  
+
 - Add better descriptions for tiles.
   [cguardia]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 New features:
 
-- Add "show_image", "show_text" and "show_comments" to existing content tile.
+- Add "show_image", "show_text", "show_comments" and "tile_class" additional
+  fields to existing content tile.
   [cekk]
 
 Bug fixes:

--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -86,8 +86,9 @@ class IExistingContentTile(model.Schema):
     )
 
     show_image = schema.Bool(
-        title=_(u'Show content image (if allowed)'),
-        default=False
+        title=_(u'Show content image (if available)'),
+        default=False,
+        required=False,
     )
 
     image_scale = schema.Choice(
@@ -97,8 +98,9 @@ class IExistingContentTile(model.Schema):
     )
 
     show_comments = schema.Bool(
-        title=_(u'Show content comments count'),
-        default=False
+        title=_(u'Show content comments count (if enabled)'),
+        default=False,
+        required=False,
     )
 
 

--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -103,6 +103,15 @@ class IExistingContentTile(model.Schema):
         required=False,
     )
 
+    tile_class = schema.TextLine(
+        title=_(u'Tile additional styles'),
+        description=_(
+            u'Insert a list of additional CSS classes that will',
+            ' be added to the tile'),
+        default=u'',
+        required=False,
+    )
+
 
 class SameContentValidator(validator.SimpleFieldValidator):
     def validate(self, content_uid):
@@ -211,6 +220,14 @@ class ExistingContentTile(Tile):
         except Exception:
             return 0
         return conversation.total_comments()
+
+    @property
+    def tile_class(self):
+        css_class = 'existing-content-tile'
+        additional_classes = self.data.get('tile_class', '')
+        if not additional_classes:
+            return css_class
+        return ' '.join([css_class, additional_classes])
 
     def __getattr__(self, name):
         # proxy attributes for this view to the selected view of the content

--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_parent
+from plone import api
+from plone.api.exc import InvalidParameterError
 from plone.app.blocks import utils
 from plone.app.blocks.tiles import renderTiles
+from plone.app.discussion.interfaces import IConversation
 from plone.app.standardtiles import PloneMessageFactory as _
 from plone.app.vocabularies.catalog import CatalogSource as CatalogSourceBase
 from plone.memoize.view import memoize
@@ -12,6 +15,7 @@ from Products.CMFCore.utils import getToolByName
 from repoze.xmliter.utils import getHTMLSerializer
 from z3c.form import validator
 from zExceptions import Unauthorized
+from ZODB.POSException import POSKeyError
 from zope import schema
 from zope.browser.interfaces import IBrowserView
 from zope.component.hooks import getSite
@@ -74,6 +78,27 @@ class IExistingContentTile(model.Schema):
     show_description = schema.Bool(
         title=_(u'Show content description'),
         default=True
+    )
+
+    show_text = schema.Bool(
+        title=_(u'Show content text'),
+        default=True
+    )
+
+    show_image = schema.Bool(
+        title=_(u'Show content image (if allowed)'),
+        default=False
+    )
+
+    image_scale = schema.Choice(
+        title=_(u'Image scale'),
+        vocabulary='plone.app.vocabularies.ImagesScales',
+        required=False,
+    )
+
+    show_comments = schema.Bool(
+        title=_(u'Show content comments count'),
+        default=False
     )
 
 
@@ -158,6 +183,32 @@ class ExistingContentTile(Tile):
                              for child in node.getchildren()])
                     for name, node in panels.items()] + [clear]
         return []
+
+    @property
+    def image_tag(self):
+        context = self.content_context
+        if not context:
+            return ''
+        try:
+            scale_view = api.content.get_view(
+                name='images',
+                context=context,
+                request=self.request,
+            )
+            scale = self.data.get('image_scale', 'thumb')
+            return scale_view.scale('image', scale=scale).tag()
+        except (InvalidParameterError, POSKeyError, AttributeError):
+            # The object doesn't have an image field
+            return ""
+
+    @property
+    def comments_count(self):
+        context = self.content_context
+        try:
+            conversation = IConversation(context)
+        except Exception:
+            return 0
+        return conversation.total_comments()
 
     def __getattr__(self, name):
         # proxy attributes for this view to the selected view of the content

--- a/plone/app/standardtiles/templates/existingcontent_view.pt
+++ b/plone/app/standardtiles/templates/existingcontent_view.pt
@@ -15,7 +15,7 @@
                     show_image python: data.get('show_image', False);
                     show_comments python: data.get('show_comments', False);">
 
-    <section>
+    <section class="${view/tile_class}">
       <h1 class="documentFirstHeading"
           tal:define="title context/Title|nothing"
           tal:condition="show_title"

--- a/plone/app/standardtiles/templates/existingcontent_view.pt
+++ b/plone/app/standardtiles/templates/existingcontent_view.pt
@@ -10,10 +10,12 @@
                     item_macro nocall:view/item_macros/content-core|nothing;
                     data view/data;
                     show_title python: data.get('show_title', True);
-                    show_description python: data.get('show_description', True)">
+                    show_description python: data.get('show_description', True);
+                    show_text python: data.get('show_text', True);
+                    show_image python: data.get('show_image', False);
+                    show_comments python: data.get('show_comments', False);">
 
     <section>
-
       <h1 class="documentFirstHeading"
           tal:define="title context/Title|nothing"
           tal:condition="show_title"
@@ -25,25 +27,31 @@
            tal:condition="show_description">
           Description
       </div>
-
-      <tal:block condition="item_macro">
-      <div tal:define="view nocall:view/default_view;
-                       plone_view context/@@plone;
-                       portal_state context/@@plone_portal_state;
-                       context_state context/@@plone_context_state;
-                       plone_layout context/@@plone_layout;
-                       lang portal_state/language;
-                       dummy python: plone_layout.mark_view(view);
-                       portal_url portal_state/portal_url;
-                       checkPermission nocall: context/portal_membership/checkPermission;
-                       site_properties context/portal_properties/site_properties;
-                       fix python:request.set('ACTUAL_URL', context.absolute_url())">
-          <div metal:use-macro="item_macro">
-              content
+      <tal:image condition="show_image">
+        <div class="content-image"
+             tal:define="image_tag view/image_tag">
+          <figure><img tal:replace="structure image_tag" /></figure>
+        </div>
+      </tal:image>
+      <tal:text condition="show_text">
+        <tal:block condition="item_macro">
+          <div tal:define="view nocall:view/default_view;
+                           plone_view context/@@plone;
+                           portal_state context/@@plone_portal_state;
+                           context_state context/@@plone_context_state;
+                           plone_layout context/@@plone_layout;
+                           lang portal_state/language;
+                           dummy python: plone_layout.mark_view(view);
+                           portal_url portal_state/portal_url;
+                           checkPermission nocall: context/portal_membership/checkPermission;
+                           site_properties context/portal_properties/site_properties;
+                           fix python:request.set('ACTUAL_URL', context.absolute_url())">
+              <div metal:use-macro="item_macro">
+                  content
+              </div>
           </div>
-      </div>
-      </tal:block>
-      <tal:block tal:condition="not:item_macro">
+        </tal:block>
+        <tal:block tal:condition="not:item_macro">
           <tal:comment tal:replace="nothing">
             XXX This case is really ONLY to make collection views work with
             the existing content view.
@@ -54,7 +62,15 @@
               </metal:block>
             </metal:entries>
           </metal:block>
-      </tal:block>
+        </tal:block>
+      </tal:text>
+      <div class="content-comments" tal:condition="show_comments"
+           tal:define="comments view/comments_count">
+        <a href="${context/absolute_url}#commenting">
+          <span class="icon-controlpanel-discussion"></span>
+          ${comments}
+        </a>
+      </div>
     </section>
   </body>
   </tal:block>

--- a/plone/app/standardtiles/tests/test_existing_content.py
+++ b/plone/app/standardtiles/tests/test_existing_content.py
@@ -325,3 +325,37 @@ class ExistingContentTileTests(TestCase):
         ).value = page2_uuid
         self.browser.getControl(name='buttons.save').click()
         self.assertIn(u'Hello World!', self.browser.contents)
+
+    def test_existing_content_tile_cssclass(self):
+        """The existing content tile takes the uuid of a content object in the
+        site and displays the result of calling its default view's content-core
+        macro
+
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description'
+        )
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_title=True'
+        )
+
+        self.assertNotIn(u'extra-class', self.unprivileged_browser.contents)
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_title=True' +
+            '&tile_class=extra-class'
+        )
+
+        self.assertIn(u'extra-class', self.unprivileged_browser.contents)

--- a/plone/app/standardtiles/tests/test_existing_content.py
+++ b/plone/app/standardtiles/tests/test_existing_content.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+from PIL import Image
+from PIL import ImageDraw
+from plone.app.discussion.interfaces import IConversation
+from plone.app.discussion.interfaces import IDiscussionSettings
+from plone.app.standardtiles.testing import PASTANDARDTILES_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.textfield import RichTextValue
+from plone.namedfile import NamedImage
+from plone.registry.interfaces import IRegistry
+from plone.testing.z2 import Browser
+from plone.uuid.interfaces import IUUID
+from unittest import TestCase
+from zope.component import createObject
+from zope.component import queryUtility
+import random
+import StringIO
+import transaction
+
+
+def image():
+    img = Image.new('RGB', (random.randint(320, 640),
+                            random.randint(320, 640)))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle(((0, 0), img.size), fill=(random.randint(0, 255),
+                                             random.randint(0, 255),
+                                             random.randint(0, 255)))
+    del draw
+
+    output = StringIO.StringIO()
+    img.save(output, 'PNG')
+    output.seek(0)
+
+    return output
+
+
+class ExistingContentTileTests(TestCase):
+    layer = PASTANDARDTILES_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.portalURL = self.portal.absolute_url()
+
+        self.browser = Browser(self.layer['app'])
+        self.browser.handleErrors = False
+        self.browser.addHeader(
+            'Authorization',
+            'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD,)
+        )
+
+        self.unprivileged_browser = Browser(self.layer['app'])
+
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        page_id = self.portal.invokeFactory(
+            'Document', 'a-simple-page',
+            title=u'A simple page', description=u'A description'
+        )
+        self.page = self.portal[page_id]
+        self.pageURL = self.portal[page_id].absolute_url()
+        transaction.commit()
+
+    def test_existing_content_tile(self):
+        """The existing content tile takes the uuid of a content object in the
+        site and displays the result of calling its default view's content-core
+        macro
+
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_text=True'
+        )
+
+        self.assertIn(u'Hello World!', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_show_title(self):
+        """
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_title=True'
+        )
+
+        self.assertIn(u'An another page', self.unprivileged_browser.contents)
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid
+        )
+
+        self.assertNotIn(u'An another page', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_show_description(self):
+        """
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_description=True'
+        )
+
+        self.assertIn(u'A description', self.unprivileged_browser.contents)
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid
+        )
+
+        self.assertNotIn(u'A description', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_show_text(self):
+        """
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_text=True'
+        )
+
+        self.assertIn(u'Hello World!', self.unprivileged_browser.contents)
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid
+        )
+
+        self.assertNotIn(u'Hello World!', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_show_image(self):
+        """
+        """
+        page_id = self.portal.invokeFactory(
+            'Document', 'a-page',
+            title=u'A page', description=u'A description',
+            text=u'Hello World!'
+        )
+        image_id = self.portal.invokeFactory(
+            'Image', 'an-image',
+            title=u'An Image', description=u'foo',
+            image=NamedImage(image(), 'image/png', filename=u'color.png')
+        )
+        page_uuid = IUUID(self.portal[page_id])
+        image_uuid = IUUID(self.portal[image_id])
+
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_image=True'
+        )
+        self.assertNotIn(u'<img src="', self.unprivileged_browser.contents)
+
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            image_uuid +
+            '&show_image=True'
+        )
+
+        self.assertIn(u'<img src="', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_show_comments(self):
+        """
+        """
+        # Allow discussion
+        registry = queryUtility(IRegistry)
+        settings = registry.forInterface(IDiscussionSettings)
+        settings.globally_enabled = True
+
+        page_id = self.portal.invokeFactory(
+            'Document', 'a-commented-page',
+            title=u'A commented page', description=u'A description',
+            text=u'Hello World!'
+        )
+        page = self.portal[page_id]
+        page_uuid = IUUID(page)
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_comments=True'
+        )
+        self.assertIn(u'0', self.unprivileged_browser.contents)
+
+        conversation = IConversation(page)
+        comment1 = createObject('plone.Comment')
+        comment1.title = 'Comment 1'
+        comment1.text = 'Comment text'
+        comment1.creator = 'jim'
+        comment1.author_username = 'Jim'
+        comment1.creation_date = datetime(2006, 9, 17, 14, 18, 12)
+        comment1.modification_date = datetime(2006, 9, 17, 14, 18, 12)
+
+        conversation.addComment(comment1)
+        transaction.commit()
+        self.unprivileged_browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid +
+            '&show_comments=True'
+        )
+        self.assertIn(u'1', self.unprivileged_browser.contents)
+
+    def test_existing_content_tile_private(self):
+        """When the current user does not have enough permissions to view
+        the content linked to existing content tile, the tile renders
+        empty"""
+        self.portal.portal_workflow.setDefaultChain(
+            'simple_publication_workflow')
+
+        page_id = self.portal.invokeFactory(
+            'Document', 'an-another-page',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!'
+        )
+        self.portal[page_id].text = RichTextValue(u'Hello World!')
+
+        page_uuid = IUUID(self.portal[page_id])
+
+        transaction.commit()
+
+        browser = Browser(self.layer['app'])
+        browser.handleErrors = False
+        browser.open(
+            self.portalURL +
+            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
+            page_uuid
+        )
+
+        self.assertNotIn(u'Hello World!', browser.contents)
+        self.assertIn(u'<body></body>', browser.contents)
+
+    def test_edit_existing_content_tile(self):
+        """The existing content tile takes the uuid of a content object in the
+        site and displays the result of calling its default view's content-core
+        macro
+
+        """
+        page_id = self.portal.invokeFactory('Document', 'an-another-page')
+        page = self.portal[page_id]
+        page_uuid = IUUID(page)
+        page.text = RichTextValue(u'Hello World!')
+
+        transaction.commit()
+
+        self.browser.open(
+            '{}/@@edit-tile/plone.app.standardtiles.existingcontent/unique'.format(
+                page.absolute_url()
+            )
+        )
+        self.browser.getControl(
+            name='plone.app.standardtiles.existingcontent.content_uid'
+        ).value = page_uuid
+        self.browser.getControl(name='buttons.save').click()
+
+        self.assertIn(u'not select the same content', self.browser.contents)
+
+        page2_id = self.portal.invokeFactory(
+            'Document', 'an-another-page-2',
+            title=u'An another page', description=u'A description',
+            text=u'Hello World!')
+        page2 = self.portal[page2_id]
+        page2_uuid = IUUID(page2)
+        page2.text = RichTextValue(u'Hello World!')
+
+        transaction.commit()
+
+        self.browser.getControl(
+            name='plone.app.standardtiles.existingcontent.content_uid'
+        ).value = page2_uuid
+        self.browser.getControl(name='buttons.save').click()
+        self.assertIn(u'Hello World!', self.browser.contents)

--- a/plone/app/standardtiles/tests/test_media.py
+++ b/plone/app/standardtiles/tests/test_media.py
@@ -10,16 +10,13 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.textfield import RichTextValue
 from plone.namedfile import NamedFile
 from plone.namedfile import NamedImage
 from plone.protect.authenticator import createToken
 from plone.testing.z2 import Browser
-from plone.uuid.interfaces import IUUID
 from unittest import TestCase
 from urllib import quote
 from zope.annotation import IAnnotations
-
 import os
 import plone.app.standardtiles.tests as test_dir
 import random
@@ -108,101 +105,6 @@ class ContentTileTests(TestCase):
         contents = self.unprivileged_browser.contents
         self.assertTrue(tile_title in contents)
         self.assertTrue(html_snippet in contents)
-
-    def test_existing_content_tile(self):
-        """The existing content tile takes the uuid of a content object in the
-        site and displays the result of calling its default view's content-core
-        macro
-
-        """
-        page_id = self.portal.invokeFactory(
-            'Document', 'an-another-page',
-            title=u'An another page', description=u'A description',
-            text=u'Hello World!'
-        )
-        self.portal[page_id].text = RichTextValue(u'Hello World!')
-
-        page_uuid = IUUID(self.portal[page_id])
-
-        transaction.commit()
-
-        self.unprivileged_browser.open(
-            self.portalURL +
-            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
-            page_uuid
-        )
-
-        self.assertIn(u'Hello World!', self.unprivileged_browser.contents)
-
-    def test_existing_content_tile_private(self):
-        """When the current user does not have enough permissions to view
-        the content linked to existing content tile, the tile renders
-        empty"""
-        self.portal.portal_workflow.setDefaultChain(
-            'simple_publication_workflow')
-
-        page_id = self.portal.invokeFactory(
-            'Document', 'an-another-page',
-            title=u'An another page', description=u'A description',
-            text=u'Hello World!'
-        )
-        self.portal[page_id].text = RichTextValue(u'Hello World!')
-
-        page_uuid = IUUID(self.portal[page_id])
-
-        transaction.commit()
-
-        browser = Browser(self.layer['app'])
-        browser.handleErrors = False
-        browser.open(
-            self.portalURL +
-            '/@@plone.app.standardtiles.existingcontent/unique?content_uid=' +
-            page_uuid
-        )
-
-        self.assertNotIn(u'Hello World!', browser.contents)
-        self.assertIn(u'<body></body>', browser.contents)
-
-    def test_edit_existing_content_tile(self):
-        """The existing content tile takes the uuid of a content object in the
-        site and displays the result of calling its default view's content-core
-        macro
-
-        """
-        page_id = self.portal.invokeFactory('Document', 'an-another-page')
-        page = self.portal[page_id]
-        page_uuid = IUUID(page)
-        page.text = RichTextValue(u'Hello World!')
-
-        transaction.commit()
-
-        self.browser.open(
-            '{}/@@edit-tile/plone.app.standardtiles.existingcontent/unique'.format(
-                page.absolute_url()
-            )
-        )
-        self.browser.getControl(
-            name='plone.app.standardtiles.existingcontent.content_uid'
-        ).value = page_uuid
-        self.browser.getControl(name='buttons.save').click()
-
-        self.assertIn(u'not select the same content', self.browser.contents)
-
-        page2_id = self.portal.invokeFactory(
-            'Document', 'an-another-page-2',
-            title=u'An another page', description=u'A description',
-            text=u'Hello World!')
-        page2 = self.portal[page2_id]
-        page2_uuid = IUUID(page2)
-        page2.text = RichTextValue(u'Hello World!')
-
-        transaction.commit()
-
-        self.browser.getControl(
-            name='plone.app.standardtiles.existingcontent.content_uid'
-        ).value = page2_uuid
-        self.browser.getControl(name='buttons.save').click()
-        self.assertIn(u'Hello World!', self.browser.contents)
 
     def test_navigation_tile(self):
         """The navigation tree tile displays a navigation tree for the context

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'test': [
             'plone.app.testing',
             'plone.app.dexterity',
+            'plone.app.discussion',
             'plone.app.widgets',
             'lxml',
         ],

--- a/test-5.x.cfg
+++ b/test-5.x.cfg
@@ -21,3 +21,4 @@ coverage = >=3.7
 plone.tiles =
 plone.app.tiles =
 plone.app.standardtiles =
+zc.buildout = 


### PR DESCRIPTION
I've added 4 additional fields to this tile:
- show_image
- show_text
- show_comments
- tile_class

In this way, editors can choose which parts of the content need to be showed or not.
Our customers are used to use a similar portlet [(redturtle.portlet.content)](https://github.com/RedTurtle/redturtle.portlet.content), and i think that this could be a nice improvement for this tile.

_tile_class_ field is another field that we commonly use, because it allows the editors to "mark" a portlet/tile with a specific (one or more) css class. This is helpful if we provide several different layouts for the same tile and they can choose which layout to use in every single tile.

For me, this field (tile_class) could be useful in every standard tile.

What do you think about this PR?