### PR TITLE
Fix noembed endpoint url to get valid JSON response.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Add better descriptions for tiles.
   [cguardia]
 
+- Fix noembed endpoint url to get valid JSON response.
+  [tmassman]
+
+
 2.1.0 (2017-02-24)
 ------------------
 

--- a/plone/app/standardtiles/embed.py
+++ b/plone/app/standardtiles/embed.py
@@ -8,7 +8,7 @@ from zope import schema
 import requests
 
 
-NOEMBED_ENDPOINT = 'https://noembed.com/embed?callback=embed_data=&url='
+NOEMBED_ENDPOINT = 'https://noembed.com/embed?url='
 
 
 class IEmbedTile(Schema):


### PR DESCRIPTION
As reported in https://github.com/plone/plone.app.mosaic/issues/362, embedding external media like YouTube currently fails due to `ValueError: No JSON object could be decoded`.

The problem is a malformed response from https://noembed.com/.

Removing the callback parameter from the URL returns the "standard" JSON, which is valid and can be decoded.