### PR TITLE
 Fix field tile not to double wrap fields tiles with full HTML template 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Bug fixes:
 - Imports are Python3 compatible
   [b4oshany]
 
+- Fix issue where field tile for title and description fields rendered
+  with double <html><body>-wrapping
+  [datakurre]
+
 2.2.0 (2017-06-09)
 ------------------
 

--- a/plone/app/standardtiles/field.py
+++ b/plone/app/standardtiles/field.py
@@ -93,7 +93,10 @@ class DexterityFieldTile(WidgetsView, Tile):
         ).allowed(self.field)
 
     def _wrap_widget(self, render):
-        return ''.join([u'<html><body>', render, '</body></html>'])
+        if render.rstrip().endswith(u'</html>'):
+            return render
+        else:
+            return ''.join([u'<html><body>', render, u'</body></html>'])
 
     def updateWidgets(self, prefix=None):
         if self.field is not None:


### PR DESCRIPTION
This was weird to go unnoticed.

Currently field tile might render <html>-wrapping for title and description fields. It might be that this can only be observed only with ESI (because lxml parser cleans this for subrequest composition).

The issue in brief:

* for unknown reason there used to be dedicated tiles for title and description with full HTML templates
* at some point we configure mosaic to use the generic field tile also for title and description
* for a reason, which I don't remember, I registered the templates from those original title and description tiles for the generic field tile for those field
* this resulted field tile wrapping those full html templates with one more html layer

Alternative fix might be to remove those template registrations, but there might be a reason why I added them in the first place.

I hope, testing for the tile ending with ``</html>`` before wrapping be cheap and safe.