### PR TITLE
Remove installation of plone.app.widgets default profile in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changelog
 - Add uninstall profile.
   [hvelarde]
 
+- Remove installation of plone.app.widgets default profile in tests.
+  In Plone 5.0/5.1 with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
+  In Plone 5.2 it will be removed.
+  [jensens]
+
 
 2.3.1 (2018-06-07)
 ------------------

--- a/plone/app/standardtiles/testing.py
+++ b/plone/app/standardtiles/testing.py
@@ -236,7 +236,6 @@ class PAStandardtilesTestType(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         # install into the Plone site
         applyProfile(portal, 'plone.app.dexterity:default')
-        applyProfile(portal, 'plone.app.widgets:default')
         applyProfile(portal, 'plone.app.standardtiles:default')
 
         # ensure plone.app.theming disabled


### PR DESCRIPTION
In Plone 5.0/5.1 with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
In Plone 5.2 will be removed.