### PR TITLE
Fix existingcontent tile form labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Changelog
 - Add custom_view also in existingcontent tile.
   [cekk]
 
+- Fix existingcontent tile form labels
+  [pnicolli]
+
 
 2.3.1 (2018-06-07)
 ------------------
@@ -70,7 +73,7 @@ Bug fixes:
 - Fix issue where image field tile template registration did not apply for
   fields on non-default fieldset
   [datakurre]
-  
+
 - Imports are Python3 compatible
   [b4oshany]
 

--- a/plone/app/standardtiles/existingcontent.py
+++ b/plone/app/standardtiles/existingcontent.py
@@ -67,7 +67,7 @@ def uuidToCatalogBrainUnrestricted(uuid):
 class IExistingContentTile(model.Schema):
 
     content_uid = schema.Choice(
-        title=_(u"Select an existing contentt"),
+        title=_(u"Select an existing content"),
         required=True,
         vocabulary='plone.app.vocabularies.Catalog',
     )
@@ -107,9 +107,8 @@ class IExistingContentTile(model.Schema):
     tile_class = schema.TextLine(
         title=_(u'Tile additional styles'),
         description=_(
-            u'Insert a list of additional CSS classes that will',
-            ' be added to the tile',
-        ),
+            u'Insert a list of additional CSS classes that will' +
+            u' be added to the tile'),
         default=u'',
         required=False,
     )


### PR DESCRIPTION
Minor fixes to labels.
As far as I know these were not translated yet (checked plone.pot in plone.app.locales master branch), so this change should not break anything.