### PR TITLE
Added linkintegrity for html and existingcontent tile. [2.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added linkintegrity for html and existingcontent tile.
+  Code was moved here from ``plone.app.blocks``, and is only active when version 5.1.0 or higher is used.
+  Fixes `issue 95 <https://github.com/plone/plone.app.blocks/issues/95>`_.
+  [maurits]
 
 
 2.4.3 (2022-09-19)

--- a/plone/app/standardtiles/configure.zcml
+++ b/plone/app/standardtiles/configure.zcml
@@ -115,6 +115,11 @@
     <adapter factory=".field.titleDisplayTemplate" name="display" />
     <adapter factory=".field.descriptionDisplayTemplate" name="display" />
     <adapter factory=".field.namedImageDisplayTemplate" name="display" />
+    <!-- Linkintegrity in plone.app.blocks is available since 5.1.0. -->
+    <configure zcml:condition="installed plone.app.blocks.linkintegrity">
+      <adapter factory=".linkintegrity.HTMLTile" />
+      <adapter factory=".linkintegrity.ExistingContentTile" />
+    </configure>
 
     <include file="upgrades.zcml" />
 

--- a/plone/app/standardtiles/linkintegrity.py
+++ b/plone/app/standardtiles/linkintegrity.py
@@ -1,0 +1,34 @@
+from plone.app.linkintegrity.interfaces import IRetriever
+from plone.app.linkintegrity.parser import extractLinks
+from plone.app.standardtiles import html
+from plone.app.standardtiles import existingcontent
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IRetriever)
+@adapter(html.HTMLTile)
+class HTMLTile(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        content = self.context.data['content']
+        # layout behavior tile storage hard codes 'utf-8' encoding
+        # thus we do the same.
+        links = set(extractLinks(content, 'utf-8'))
+        return links
+
+
+@implementer(IRetriever)
+@adapter(existingcontent.ExistingContentTile)
+class ExistingContentTile(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        content_uid = self.context.data['content_uid']
+        links = set(['../resolveuid/%s' % content_uid])
+        return links


### PR DESCRIPTION
Code was moved here from `plone.app.blocks`, and is only active when version 5.1.0 or higher is used. Fixes https://github.com/plone/plone.app.blocks/issues/95