### PR TITLE
Fix CMFDynamicViewFTI import.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
+- Fix broken CMFDynamicViewFTI import.
+  [thet]
+
 - Fix byline viewlet name
   [frapell]
 

--- a/src/plone/app/standardtiles/navigation.py
+++ b/src/plone/app/standardtiles/navigation.py
@@ -15,7 +15,7 @@ from plone.tiles import Tile
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.utils import getToolByName
-from Products.CMFDynamicViewFTI.interface import IBrowserDefault
+from Products.CMFDynamicViewFTI.interfaces import IBrowserDefault
 from Products.CMFPlone.browser.navtree import NavtreeQueryBuilder
 from Products.CMFPlone.browser.navtree import SitemapNavtreeStrategy
 from Products.CMFPlone.interfaces import INonStructuralFolder


### PR DESCRIPTION
Fix import with error:
```
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/zope.configuration-4.4.1-py3.11.egg/zope/configuration/config.py", line 225, in resolve
    __import__(mname)
  File "/home/_thet/data/dev/sprints/plone6ui/REPOS/buildout.coredev/src/plone.app.standardtiles/src/plone/app/standardtiles/navigation.py", line 18, in <module>
    from Products.CMFDynamicViewFTI.interface import IBrowserDefault
ModuleNotFoundError: No module named 'Products.CMFDynamicViewFTI.interface'
```