### PR TITLE
Add `tile.id` to contentlisting css class to make it unique selectable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,8 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
-Bug fixes:
-
-- *add item here*
+- Add ``tile.id`` to contentlisting css classes to make it unique selectable.
+  [petschki]
 
 
 3.2.1 (2025-02-06)

--- a/src/plone/app/standardtiles/contentlisting.py
+++ b/src/plone/app/standardtiles/contentlisting.py
@@ -296,11 +296,11 @@ class ContentListingTile(Tile):
 
     @property
     def tile_class(self):
-        css_class = "contentlisting-tile"
+        css_classes = ["contentlisting-tile", f"tile-{self.id}"]
         additional_classes = self.data.get("tile_class", "")
-        if not additional_classes:
-            return css_class
-        return " ".join([css_class, additional_classes])
+        if additional_classes:
+            css_classes.append(additional_classes)
+        return " ".join(css_classes)
 
 
 @provider(IVocabularyFactory)


### PR DESCRIPTION
Usecase: we often refactor the contentlisting template to load the next batch with `pat-inject` ... this is for conveniently selecting the right contentlisting.
